### PR TITLE
Fix math formatting in document

### DIFF
--- a/docs/MATHEMATICAL_FORMULATION.md
+++ b/docs/MATHEMATICAL_FORMULATION.md
@@ -135,7 +135,9 @@ where \(v_{t,i}\) is the \(i\)-th token in the value sequence and \(v_{t,<i}\) r
 
 **Theorem 1 (Policy Gradient with θ-Dependent Rewards):** The system maximizes the following objective function:
 
-$$\mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \bar{R}(\tau) \right]$$
+$$
+\mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \bar{R}(\tau) \right]
+$$
 
 where:
 - $\bar{R}(\tau) = \frac{1}{T} \sum_{t=1}^T r_{\theta,t}$ is the **average reward over the entire trajectory**
@@ -143,18 +145,26 @@ where:
 
 **Detailed Gradient Derivation:** Since both the policy and rewards depend on \(\theta\), we apply the chain rule:
 
-$$\nabla_\theta \mathcal{J}(\theta) = \nabla_\theta \mathbb{E}_{\tau \sim \pi_\theta} \left[ \bar{R}(\tau) \right]$$
+$$
+\nabla_\theta \mathcal{J}(\theta) = \nabla_\theta \mathbb{E}_{\tau \sim \pi_\theta} \left[ \bar{R}(\tau) \right]
+$$
 
 **Step 1: Expand $\bar{R}(\tau)$**
-$$\mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \frac{1}{T} \sum_{t=1}^T r_{\theta,t} \right]$$
+$$
+\mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \frac{1}{T} \sum_{t=1}^T r_{\theta,t} \right]
+$$
 
 **Step 2: Apply chain rule for θ-dependent rewards and policy**
-$$\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \frac{1}{T} \sum_{t=1}^T \nabla_\theta r_{\theta,t} \right] + \mathbb{E}_{\tau \sim \pi_\theta} \left[ \nabla_\theta \log \pi_\theta(\tau) \cdot \bar{R}(\tau) \right]$$
+$$
+\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \frac{1}{T} \sum_{t=1}^T \nabla_\theta r_{\theta,t} \right] + \mathbb{E}_{\tau \sim \pi_\theta} \left[ \nabla_\theta \log \pi_\theta(\tau) \cdot \bar{R}(\tau) \right]
+$$
 
 **Step 3: Expand trajectory log-probability**
 Since $\nabla_\theta \log \pi_\theta(\tau) = \sum_{t=1}^T \nabla_\theta \log \pi_\theta(a_t | s_t)$:
 
-$$\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \frac{1}{T} \sum_{t=1}^T \nabla_\theta r_{\theta,t} + \bar{R}(\tau) \sum_{t=1}^T \nabla_\theta \log \pi_\theta(a_t | s_t) \right]$$
+$$
+\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \frac{1}{T} \sum_{t=1}^T \nabla_\theta r_{\theta,t} + \bar{R}(\tau) \sum_{t=1}^T \nabla_\theta \log \pi_\theta(a_t | s_t) \right]
+$$
 
 **Key Insight:** This exact derivation shows that each action $a_t$ should be weighted by the **same trajectory average** $\bar{R}(\tau)$. This is much simpler than step-specific advantages and matches our implementation exactly!
 

--- a/docs/MATHEMATICAL_FORMULATION.md
+++ b/docs/MATHEMATICAL_FORMULATION.md
@@ -38,7 +38,9 @@ The AttentionGuidedRL system implements a novel approach where a base language m
 
 **Definition 1 (State Space):** At timestep \(t\), the state \(s_t\) consists of:
 
-\[s_t = (c_t, \mathcal{K}_t^{\text{available}})\]
+$$
+s_t = (c_t, \mathcal{K}_t^{\text{available}})
+$$
 
 where:
 - $c_t \in \mathbb{Z}^{L_t}$ is the context sequence of length $L_t$
@@ -46,13 +48,17 @@ where:
 
 **Definition 2 (Action Space):** The action space \(\mathcal{A}_t\) at timestep \(t\) is the set of available key indices:
 
-\[\mathcal{A}_t = \mathcal{K}_t^{\text{available}}\]
+$$
+\mathcal{A}_t = \mathcal{K}_t^{\text{available}}
+$$
 
 ### Trajectory and Episode Structure
 
 A trajectory \(\tau\) consists of \(T\) steps:
 
-\[\tau = \{(s_1, a_1, r_1), (s_2, a_2, r_2), \ldots, (s_T, a_T, r_T)\}\]
+$$
+\tau = \{(s_1, a_1, r_1), (s_2, a_2, r_2), \ldots, (s_T, a_T, r_T)\}
+$$
 
 where \(T\) is the number of key-value pairs per episode (NUM_KV_PAIRS in the code).
 
@@ -66,7 +72,9 @@ The policy $\pi_\theta$ operates through a vector query mechanism parameterized 
 
 **Definition 3 (Query Vector Generation):** Given context \(c_t\), the query vector is generated as:
 
-\[q_t = \text{Embed}_\theta(c_t \oplus [\text{"Query"}])_{-1}\]
+$$
+q_t = \text{Embed}_\theta(c_t \oplus [\text{"Query"}])_{-1}
+$$
 
 where:
 - $\text{Embed}_\theta(\cdot)$ extracts embeddings from the second-to-last attention layer
@@ -82,7 +90,9 @@ The system handles both standard Multi-Head Attention (MHA) and Grouped Query At
 
 **Definition 4 (Head-wise Similarity Computation):** For each attention head \(h \in \{1, 2, \ldots, H\}\) and key \(k\):
 
-\[\text{sim}_{t,k}^{(h)} = \frac{(q_t^{(h)})^T k_k^{(\text{group}(h))}}{\sqrt{d_{\text{head}}}} \cdot \frac{1}{\tau}\]
+$$
+\text{sim}_{t,k}^{(h)} = \frac{(q_t^{(h)})^T k_k^{(\text{group}(h))}}{\sqrt{d_{\text{head}}}} \cdot \frac{1}{\tau}
+$$
 
 where:
 - $q_t^{(h)} \in \mathbb{R}^{d_{\text{head}}}$ is the query for head $h$
@@ -95,11 +105,15 @@ where:
 
 **Definition 5 (Per-Head Probability Distribution):** For each head \(h\), the probability distribution over keys is:
 
-\[p_{t,k}^{(h)} = \frac{\exp(\text{sim}_{t,k}^{(h)})}{\sum_{k' \in \mathcal{K}_t^{\text{available}}} \exp(\text{sim}_{t,k'}^{(h)})}\]
+$$
+p_{t,k}^{(h)} = \frac{\exp(\text{sim}_{t,k}^{(h)})}{\sum_{k' \in \mathcal{K}_t^{\text{available}}} \exp(\text{sim}_{t,k'}^{(h)})}
+$$
 
 **Definition 6 (Policy Distribution):** The final policy distribution is obtained by averaging over heads:
 
-\[\pi_\theta(k | s_t) = \frac{1}{H} \sum_{h=1}^{H} p_{t,k}^{(h)}\]
+$$
+\pi_\theta(k | s_t) = \frac{1}{H} \sum_{h=1}^{H} p_{t,k}^{(h)}
+$$
 
 ---
 
@@ -107,7 +121,9 @@ where:
 
 **Definition 7 (θ-Dependent Step Reward):** The reward at step \(t\) depends on the current model parameters \(\theta\):
 
-\[r_{\theta,t} = \log p_\theta(v_t | c_t, k_t)\]
+$$
+r_{\theta,t} = \log p_\theta(v_t | c_t, k_t)
+$$
 
 where:
 - $v_t$ are the value tokens at step $t$
@@ -117,7 +133,9 @@ where:
 
 **Definition 8 (Conditional Log Probability):** The conditional log probability is computed as:
 
-\[\log p_\theta(v_t | c_t, k_t) = \frac{1}{|v_t|} \sum_{i=1}^{|v_t|} \log p_\theta(v_{t,i} | c_t, k_t, v_{t,<i})\]
+$$
+\log p_\theta(v_t | c_t, k_t) = \frac{1}{|v_t|} \sum_{i=1}^{|v_t|} \log p_\theta(v_{t,i} | c_t, k_t, v_{t,<i})
+$$
 
 where \(v_{t,i}\) is the \(i\)-th token in the value sequence and \(v_{t,<i}\) represents the preceding tokens.
 
@@ -187,7 +205,9 @@ This approach gives each action credit for the overall trajectory performance, w
 
 **Theorem 2 (Advantage-Based Policy Gradient with θ-Dependent Reward Chain Rule):** The loss function combines advantage-based policy gradients with reward gradient terms:
 
-\[\mathcal{L}(\theta) = \mathbb{E}_{\text{batch}} \left[ -\sum_{t=1}^T \tilde{A}_t \cdot \log \pi_\theta(a_t | s_t) - \lambda \sum_{t=1}^T r_{\theta,t} \right]\]
+$$
+\mathcal{L}(\theta) = \mathbb{E}_{\text{batch}} \left[ -\sum_{t=1}^T \tilde{A}_t \cdot \log \pi_\theta(a_t | s_t) - \lambda \sum_{t=1}^T r_{\theta,t} \right]
+$$
 
 **Decomposition into Two Terms:**
 
@@ -211,7 +231,9 @@ This approach gives each action credit for the overall trajectory performance, w
 
 **Definition 12 (Current Policy Sampling):** All trajectories are sampled using the current policy:
 
-\[\tau \sim \pi_\theta\]
+$$
+\tau \sim \pi_\theta
+$$
 
 - Trajectories are generated using the current adapter model (with LoRA weights)
 - This ensures truly on-policy data for policy gradient updates
@@ -220,7 +242,9 @@ This approach gives each action credit for the overall trajectory performance, w
 
 **Mathematical Formulation:** The chain rule policy gradient for average future rewards becomes:
 
-\[\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \sum_{t=1}^T \tilde{A}_t \cdot \nabla_\theta \log \pi_\theta(a_t | s_t) + \lambda \sum_{t=1}^T \nabla_\theta r_{\theta,t} \right]\]
+$$
+\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \sum_{t=1}^T \tilde{A}_t \cdot \nabla_\theta \log \pi_\theta(a_t | s_t) + \lambda \sum_{t=1}^T \nabla_\theta r_{\theta,t} \right]
+$$
 
 where each action is weighted by its normalized advantage $\tilde{A}_t$ based on average future rewards $\bar{R}_t(\tau)$.
 
@@ -366,13 +390,17 @@ Input: Hyperparameters γ, learning rate, batch size
 
 **Lemma 2 (Multi-Head Averaging):** The averaging operation over attention heads in Equation (6) preserves the probability distribution property:
 
-\[\sum_{k \in \mathcal{K}_t^{\text{available}}} \pi_\theta(k | s_t) = 1\]
+$$
+\sum_{k \in \mathcal{K}_t^{\text{available}}} \pi_\theta(k | s_t) = 1
+$$
 
 ### Chain Rule Properties
 
 **Theorem 3 (Self-Consistent Learning):** The chain rule approach ensures self-consistent parameter updates:
 
-\[\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}[R_\theta(\tau) \cdot \nabla_\theta \log \pi_\theta(\tau) + \nabla_\theta R_\theta(\tau)]\]
+$$
+\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}[R_\theta(\tau) \cdot \nabla_\theta \log \pi_\theta(\tau) + \nabla_\theta R_\theta(\tau)]
+$$
 
 Both terms optimize the same parameters $\theta$, creating a unified learning signal where the model learns to both select high-reward actions AND accurately evaluate their outcomes.
 
@@ -410,7 +438,9 @@ This mathematical formulation describes a sophisticated reinforcement learning s
 
 The key innovation is the **average future reward θ-dependent formulation** with proper chain rule application:
 
-\[\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \sum_{t=1}^T \tilde{A}_t \cdot \nabla_\theta \log \pi_\theta(a_t | s_t) + \lambda \sum_{t=1}^T \nabla_\theta r_{\theta,t} \right]\]
+$$
+\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \sum_{t=1}^T \tilde{A}_t \cdot \nabla_\theta \log \pi_\theta(a_t | s_t) + \lambda \sum_{t=1}^T \nabla_\theta r_{\theta,t} \right]
+$$
 
 where $\tilde{A}_t$ are normalized advantages based on average future rewards $\bar{R}_t(\tau) = \frac{1}{T-t+1} \sum_{s=t}^T r_{\theta,s}$.
 


### PR DESCRIPTION
Standardize math formatting in `docs/MATHEMATICAL_FORMULATION.md` to use block-level `$$` for display equations and fix LaTeX escaping issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-347875a5-0ac2-4984-9aa6-36bec1911169">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-347875a5-0ac2-4984-9aa6-36bec1911169">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

