### PR TITLE
Fix math formatting in GitHub repo

### DIFF
--- a/docs/MATHEMATICAL_FORMULATION.md
+++ b/docs/MATHEMATICAL_FORMULATION.md
@@ -36,31 +36,31 @@ The AttentionGuidedRL system implements a novel approach where a base language m
 
 ### State Space and Action Space
 
-**Definition 1 (State Space):** At timestep \(t\), the state \(s_t\) consists of:
+**Definition 1 (State Space):** At timestep \\(t\\), the state \\(s_t\\) consists of:
 
 $$
-s_t = (c_t, \mathcal{K}_t^{\text{available}})
+s_t = (c_t, \\mathcal{K}_t^{\\text{available}})
 $$
 
 where:
-- $c_t \in \mathbb{Z}^{L_t}$ is the context sequence of length $L_t$
-- $\mathcal{K}_t^{\text{available}} \subseteq \{1, 2, \ldots, K\}$ is the set of available key indices
+- $c_t \\in \\mathbb{Z}^{L_t}$ is the context sequence of length $L_t$
+- $\\mathcal{K}_t^{\\text{available}} \\subseteq \\{1, 2, \\ldots, K\\}$ is the set of available key indices
 
-**Definition 2 (Action Space):** The action space \(\mathcal{A}_t\) at timestep \(t\) is the set of available key indices:
+**Definition 2 (Action Space):** The action space \\(\\mathcal{A}_t\\) at timestep \\(t\\) is the set of available key indices:
 
 $$
-\mathcal{A}_t = \mathcal{K}_t^{\text{available}}
+\\mathcal{A}_t = \\mathcal{K}_t^{\\text{available}}
 $$
 
 ### Trajectory and Episode Structure
 
-A trajectory \(\tau\) consists of \(T\) steps:
+A trajectory \\(\\tau\\) consists of \\(T\\) steps:
 
 $$
-\tau = \{(s_1, a_1, r_1), (s_2, a_2, r_2), \ldots, (s_T, a_T, r_T)\}
+\\tau = \\{(s_1, a_1, r_1), (s_2, a_2, r_2), \\ldots, (s_T, a_T, r_T)\\}
 $$
 
-where \(T\) is the number of key-value pairs per episode (NUM_KV_PAIRS in the code).
+where \\(T\\) is the number of key-value pairs per episode (NUM_KV_PAIRS in the code).
 
 ---
 
@@ -68,19 +68,19 @@ where \(T\) is the number of key-value pairs per episode (NUM_KV_PAIRS in the co
 
 ### Vector Query Generation
 
-The policy $\pi_\theta$ operates through a vector query mechanism parameterized by LoRA adapter weights $\theta$.
+The policy $\\pi_\\theta$ operates through a vector query mechanism parameterized by LoRA adapter weights $\\theta$.
 
-**Definition 3 (Query Vector Generation):** Given context \(c_t\), the query vector is generated as:
+**Definition 3 (Query Vector Generation):** Given context \\(c_t\\), the query vector is generated as:
 
 $$
-q_t = \text{Embed}_\theta(c_t \oplus [\text{"Query"}])_{-1}
+q_t = \\text{Embed}_\\theta(c_t \\oplus [\\text{"Query"}])_{-1}
 $$
 
 where:
-- $\text{Embed}_\theta(\cdot)$ extracts embeddings from the second-to-last attention layer
-- $\oplus$ denotes sequence concatenation
-- $(\cdot)_{-1}$ extracts the embedding of the last token (the "Query" token)
-- $q_t \in \mathbb{R}^{d_{\text{model}}}$ where $d_{\text{model}}$ is the model dimension
+- $\\text{Embed}_\\theta(\\cdot)$ extracts embeddings from the second-to-last attention layer
+- $\\oplus$ denotes sequence concatenation
+- $(\\cdot)_{-1}$ extracts the embedding of the last token (the "Query" token)
+- $q_t \\in \\mathbb{R}^{d_{\\text{model}}}$ where $d_{\\text{model}}$ is the model dimension
 
 This focused extraction ensures that the model learns to encode its query intent specifically into the "Query" token, rather than diluting the signal across the entire context.
 
@@ -88,62 +88,62 @@ This focused extraction ensures that the model learns to encode its query intent
 
 The system handles both standard Multi-Head Attention (MHA) and Grouped Query Attention (GQA).
 
-**Definition 4 (Head-wise Similarity Computation):** For each attention head \(h \in \{1, 2, \ldots, H\}\) and key \(k\):
+**Definition 4 (Head-wise Similarity Computation):** For each attention head $h \\in \\{1, 2, \\ldots, H\\}$ and key $k$:
 
 $$
-\text{sim}_{t,k}^{(h)} = \frac{(q_t^{(h)})^T k_k^{(\text{group}(h))}}{\sqrt{d_{\text{head}}}} \cdot \frac{1}{\tau}
+\\text{sim}_{t,k}^{(h)} = \\frac{(q_t^{(h)})^T k_k^{(\\text{group}(h))}}{\\sqrt{d_{\\text{head}}}} \\cdot \\frac{1}{\\tau}
 $$
 
 where:
-- $q_t^{(h)} \in \mathbb{R}^{d_{\text{head}}}$ is the query for head $h$
-- $k_k^{(\text{group}(h))} \in \mathbb{R}^{d_{\text{head}}}$ is the key for the corresponding group
-- $\text{group}(h) = \lfloor h \cdot G / H \rfloor$ maps heads to groups (for GQA)
+- $q_t^{(h)} \\in \\mathbb{R}^{d_{\\text{head}}}$ is the query for head $h$
+- $k_k^{(\\text{group}(h))} \\in \\mathbb{R}^{d_{\\text{head}}}$ is the key for the corresponding group
+- $\\text{group}(h) = \\lfloor h \\cdot G / H \\rfloor$ maps heads to groups (for GQA)
 - $G$ is the number of key-value groups
 - $H$ is the number of query heads
-- $d_{\text{head}} = d_{\text{model}} / H$ is the head dimension
-- $\tau = 1.0$ is the temperature parameter
+- $d_{\\text{head}} = d_{\\text{model}} / H$ is the head dimension
+- $\\tau = 1.0$ is the temperature parameter
 
-**Definition 5 (Per-Head Probability Distribution):** For each head \(h\), the probability distribution over keys is:
+**Definition 5 (Per-Head Probability Distribution):** For each head $h$, the probability distribution over keys is:
 
 $$
-p_{t,k}^{(h)} = \frac{\exp(\text{sim}_{t,k}^{(h)})}{\sum_{k' \in \mathcal{K}_t^{\text{available}}} \exp(\text{sim}_{t,k'}^{(h)})}
+p_{t,k}^{(h)} = \\frac{\\exp(\\text{sim}_{t,k}^{(h)})}{\\sum_{k' \\in \\mathcal{K}_t^{\\text{available}}} \\exp(\\text{sim}_{t,k'}^{(h)})}
 $$
 
 **Definition 6 (Policy Distribution):** The final policy distribution is obtained by averaging over heads:
 
 $$
-\pi_\theta(k | s_t) = \frac{1}{H} \sum_{h=1}^{H} p_{t,k}^{(h)}
+\\pi_\\theta(k | s_t) = \\frac{1}{H} \\sum_{h=1}^{H} p_{t,k}^{(h)}
 $$
 
 ---
 
 ## Reward Function
 
-**Definition 7 (θ-Dependent Step Reward):** The reward at step \(t\) depends on the current model parameters \(\theta\):
+**Definition 7 (θ-Dependent Step Reward):** The reward at step $t$ depends on the current model parameters $\\theta$:
 
 $$
-r_{\theta,t} = \log p_\theta(v_t | c_t, k_t)
+r_{\\theta,t} = \\log p_\\theta(v_t | c_t, k_t)
 $$
 
 where:
 - $v_t$ are the value tokens at step $t$
 - $k_t$ are the selected key tokens at step $t$
-- $p_\theta(\cdot)$ is the current adapter model probability (with LoRA parameters $\theta$)
+- $p_\\theta(\\cdot)$ is the current adapter model probability (with LoRA parameters $\\theta$)
 - The reward is computed using the **current model**, making it θ-dependent
 
 **Definition 8 (Conditional Log Probability):** The conditional log probability is computed as:
 
 $$
-\log p_\theta(v_t | c_t, k_t) = \frac{1}{|v_t|} \sum_{i=1}^{|v_t|} \log p_\theta(v_{t,i} | c_t, k_t, v_{t,<i})
+\\log p_\\theta(v_t | c_t, k_t) = \\frac{1}{|v_t|} \\sum_{i=1}^{|v_t|} \\log p_\\theta(v_{t,i} | c_t, k_t, v_{t,<i})
 $$
 
-where \(v_{t,i}\) is the \(i\)-th token in the value sequence and \(v_{t,<i}\) represents the preceding tokens.
+where $v_{t,i}$ is the $i$-th token in the value sequence and $v_{t,<i}$ represents the preceding tokens.
 
 **Implementation Note:** For computational efficiency, rewards are computed once during trajectory generation and reused during the chain rule update. This preserves the same gradient flow while reducing memory usage.
 
 **Configuration Option:** The system supports two reward modes:
-- `subtract_base_model_logprobs=True`: $r_{\theta,t} = \log p_\theta(v_t | c_t, k_t) - \log p_{\text{ref}}(v_t | c_t, k_t)$
-- `subtract_base_model_logprobs=False`: $r_{\theta,t} = \log p_\theta(v_t | c_t, k_t)$ (default)
+- `subtract_base_model_logprobs=True`: $r_{\\theta,t} = \\log p_\\theta(v_t | c_t, k_t) - \\log p_{\\text{ref}}(v_t | c_t, k_t)$
+- `subtract_base_model_logprobs=False`: $r_{\\theta,t} = \\log p_\\theta(v_t | c_t, k_t)$ (default)
 
 ---
 
@@ -154,46 +154,46 @@ where \(v_{t,i}\) is the \(i\)-th token in the value sequence and \(v_{t,<i}\) r
 **Theorem 1 (Policy Gradient with θ-Dependent Rewards):** The system maximizes the following objective function:
 
 $$
-\mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \bar{R}(\tau) \right]
+\\mathcal{J}(\\theta) = \\mathbb{E}_{\\tau \\sim \\pi_\\theta} \\left[ \\bar{R}(\\tau) \\right]
 $$
 
 where:
-- $\bar{R}(\tau) = \frac{1}{T} \sum_{t=1}^T r_{\theta,t}$ is the **average reward over the entire trajectory**
-- $r_{\theta,t} = \frac{1}{|v_t|} \sum_{i=1}^{|v_t|} \log p_\theta(v_{t,i} | c_t, k_t, v_{t,<i})$ is the instantaneous θ-dependent reward
+- $\\bar{R}(\\tau) = \\frac{1}{T} \\sum_{t=1}^T r_{\\theta,t}$ is the **average reward over the entire trajectory**
+- $r_{\\theta,t} = \\frac{1}{|v_t|} \\sum_{i=1}^{|v_t|} \\log p_\\theta(v_{t,i} | c_t, k_t, v_{t,<i})$ is the instantaneous θ-dependent reward
 
-**Detailed Gradient Derivation:** Since both the policy and rewards depend on \(\theta\), we apply the chain rule:
+**Detailed Gradient Derivation:** Since both the policy and rewards depend on $\\theta$, we apply the chain rule:
 
 $$
-\nabla_\theta \mathcal{J}(\theta) = \nabla_\theta \mathbb{E}_{\tau \sim \pi_\theta} \left[ \bar{R}(\tau) \right]
+\\nabla_\\theta \\mathcal{J}(\\theta) = \\nabla_\\theta \\mathbb{E}_{\\tau \\sim \\pi_\\theta} \\left[ \\bar{R}(\\tau) \\right]
 $$
 
-**Step 1: Expand $\bar{R}(\tau)$**
+**Step 1: Expand $\\bar{R}(\\tau)$**
 $$
-\mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \frac{1}{T} \sum_{t=1}^T r_{\theta,t} \right]
+\\mathcal{J}(\\theta) = \\mathbb{E}_{\\tau \\sim \\pi_\\theta} \\left[ \\frac{1}{T} \\sum_{t=1}^T r_{\\theta,t} \\right]
 $$
 
 **Step 2: Apply chain rule for θ-dependent rewards and policy**
 $$
-\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \frac{1}{T} \sum_{t=1}^T \nabla_\theta r_{\theta,t} \right] + \mathbb{E}_{\tau \sim \pi_\theta} \left[ \nabla_\theta \log \pi_\theta(\tau) \cdot \bar{R}(\tau) \right]
+\\nabla_\\theta \\mathcal{J}(\\theta) = \\mathbb{E}_{\\tau \\sim \\pi_\\theta} \\left[ \\frac{1}{T} \\sum_{t=1}^T \\nabla_\\theta r_{\\theta,t} \\right] + \\mathbb{E}_{\\tau \\sim \\pi_\\theta} \\left[ \\nabla_\\theta \\log \\pi_\\theta(\\tau) \\cdot \\bar{R}(\\tau) \\right]
 $$
 
 **Step 3: Expand trajectory log-probability**
-Since $\nabla_\theta \log \pi_\theta(\tau) = \sum_{t=1}^T \nabla_\theta \log \pi_\theta(a_t | s_t)$:
+Since $\\nabla_\\theta \\log \\pi_\\theta(\\tau) = \\sum_{t=1}^T \\nabla_\\theta \\log \\pi_\\theta(a_t | s_t)$:
 
 $$
-\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \frac{1}{T} \sum_{t=1}^T \nabla_\theta r_{\theta,t} + \bar{R}(\tau) \sum_{t=1}^T \nabla_\theta \log \pi_\theta(a_t | s_t) \right]
+\\nabla_\\theta \\mathcal{J}(\\theta) = \\mathbb{E}_{\\tau \\sim \\pi_\\theta} \\left[ \\frac{1}{T} \\sum_{t=1}^T \\nabla_\\theta r_{\\theta,t} + \\bar{R}(\\tau) \\sum_{t=1}^T \\nabla_\\theta \\log \\pi_\\theta(a_t | s_t) \\right]
 $$
 
-**Key Insight:** This exact derivation shows that each action $a_t$ should be weighted by the **same trajectory average** $\bar{R}(\tau)$. This is much simpler than step-specific advantages and matches our implementation exactly!
+**Key Insight:** This exact derivation shows that each action $a_t$ should be weighted by the **same trajectory average** $\\bar{R}(\\tau)$. This is much simpler than step-specific advantages and matches our implementation exactly!
 
-**Perfect Alignment:** The mathematical derivation and implementation are now **exactly consistent**! Each action is weighted by the same trajectory average $\bar{R}(\tau)$ with no baseline subtraction or normalization, providing a clean and theoretically sound approach.
+**Perfect Alignment:** The mathematical derivation and implementation are now **exactly consistent**! Each action is weighted by the same trajectory average $\\bar{R}(\\tau)$ with no baseline subtraction or normalization, providing a clean and theoretically sound approach.
 
 ### Practical Implementation
 
 **Mathematical Consistency:** The rigorous derivation perfectly matches our implementation:
 
-- **Theory:** $\nabla_\theta \log \pi_\theta(a_t | s_t) \cdot \bar{R}(\tau)$
-- **Implementation:** $\nabla_\theta \log \pi_\theta(a_t | s_t) \cdot \bar{R}(\tau)$
+- **Theory:** $\\nabla_\\theta \\log \\pi_\\theta(a_t | s_t) \\cdot \\bar{R}(\\tau)$
+- **Implementation:** $\\nabla_\\theta \\log \\pi_\\theta(a_t | s_t) \\cdot \\bar{R}(\\tau)$
 
 This approach gives each action credit for the overall trajectory performance, which is mathematically correct and conceptually simple.
 
@@ -206,20 +206,20 @@ This approach gives each action credit for the overall trajectory performance, w
 **Theorem 2 (Advantage-Based Policy Gradient with θ-Dependent Reward Chain Rule):** The loss function combines advantage-based policy gradients with reward gradient terms:
 
 $$
-\mathcal{L}(\theta) = \mathbb{E}_{\text{batch}} \left[ -\sum_{t=1}^T \tilde{A}_t \cdot \log \pi_\theta(a_t | s_t) - \lambda \sum_{t=1}^T r_{\theta,t} \right]
+\\mathcal{L}(\\theta) = \\mathbb{E}_{\\text{batch}} \\left[ -\\sum_{t=1}^T \\tilde{A}_t \\cdot \\log \\pi_\\theta(a_t | s_t) - \\lambda \\sum_{t=1}^T r_{\\theta,t} \\right]
 $$
 
 **Decomposition into Two Terms:**
 
-1. **Policy Gradient Term**: $-\sum_{t=1}^T \tilde{A}_t \cdot \log \pi_\theta(a_t | s_t)$
-   - Uses **normalized advantages** $\tilde{A}_t$ for better credit assignment
+1. **Policy Gradient Term**: $-\\sum_{t=1}^T \\tilde{A}_t \\cdot \\log \\pi_\\theta(a_t | s_t)$
+   - Uses **normalized advantages** $\\tilde{A}_t$ for better credit assignment
    - Encourages actions that perform better than the batch baseline
    - Typical magnitude: ~1-10 (normalized)
 
-2. **Reward Gradient Term**: $-\lambda \sum_{t=1}^T r_{\theta,t}$ (Differentiable)
-   - Direct optimization of reward model parameters via $\nabla_\theta r_{\theta,t}$
-   - Implemented by recomputing $r_{\theta,t}$ in the training step without `no_grad`
-   - Scaled by $\lambda$ (default 0.1) to balance with the policy term
+2. **Reward Gradient Term**: $-\\lambda \\sum_{t=1}^T r_{\\theta,t}$ (Differentiable)
+   - Direct optimization of reward model parameters via $\\nabla_\\theta r_{\\theta,t}$
+   - Implemented by recomputing $r_{\\theta,t}$ in the training step without `no_grad`
+   - Scaled by $\\lambda$ (default 0.1) to balance with the policy term
 
 **Key Properties:**
 1. **Stable Magnitudes**: Both terms scaled to similar ranges (preventing one from dominating)
@@ -232,7 +232,7 @@ $$
 **Definition 12 (Current Policy Sampling):** All trajectories are sampled using the current policy:
 
 $$
-\tau \sim \pi_\theta
+\\tau \\sim \\pi_\\theta
 $$
 
 - Trajectories are generated using the current adapter model (with LoRA weights)
@@ -243,34 +243,34 @@ $$
 **Mathematical Formulation:** The chain rule policy gradient for average future rewards becomes:
 
 $$
-\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \sum_{t=1}^T \tilde{A}_t \cdot \nabla_\theta \log \pi_\theta(a_t | s_t) + \lambda \sum_{t=1}^T \nabla_\theta r_{\theta,t} \right]
+\\nabla_\\theta \\mathcal{J}(\\theta) = \\mathbb{E}_{\\tau \\sim \\pi_\\theta} \\left[ \\sum_{t=1}^T \\tilde{A}_t \\cdot \\nabla_\\theta \\log \\pi_\\theta(a_t | s_t) + \\lambda \\sum_{t=1}^T \\nabla_\\theta r_{\\theta,t} \\right]
 $$
 
-where each action is weighted by its normalized advantage $\tilde{A}_t$ based on average future rewards $\bar{R}_t(\tau)$.
+where each action is weighted by its normalized advantage $\\tilde{A}_t$ based on average future rewards $\\bar{R}_t(\\tau)$.
 
 ### Chain Rule Implementation Details
 
 **Definition 13 (Chain Rule Gradient Decomposition):** The θ-dependent objective decomposes into two complementary terms:
 
-1. **Policy Term**: $\sum_{t=1}^T \tilde{A}_t \cdot \nabla_\theta \log \pi_\theta(a_t | s_t)$
-   - Uses normalized advantages $\tilde{A}_t$ based on average future rewards $\bar{R}_t(\tau)$
+1. **Policy Term**: $\\sum_{t=1}^T \\tilde{A}_t \\cdot \\nabla_\\theta \\log \\pi_\\theta(a_t | s_t)$
+   - Uses normalized advantages $\\tilde{A}_t$ based on average future rewards $\\bar{R}_t(\\tau)$
    - Actions weighted by how much better their future outcomes are than baseline
    - Better credit assignment: step-specific advantages rather than trajectory-level returns
 
-2. **Reward Term**: $\lambda \sum_{t=1}^T \nabla_\theta r_{\theta,t}$
+2. **Reward Term**: $\\lambda \\sum_{t=1}^T \\nabla_\\theta r_{\\theta,t}$
    - Direct optimization of the reward function itself
    - Encourages the model to assign higher probabilities to selected value tokens
    - Provides natural regularization without artificial penalties
-   - Scaled by $\lambda = 0.1$ for balanced optimization
+   - Scaled by $\\lambda = 0.1$ for balanced optimization
 
-**Key Property:** Both terms optimize the same parameters θ, creating a **self-consistent learning signal** where the model learns to both select good actions AND accurately evaluate their outcomes.
+**Key Property:** Both terms optimize the same parameters $\\theta$, creating a **self-consistent learning signal** where the model learns to both select good actions AND accurately evaluate their outcomes.
 
 **Comparison with Standard REINFORCE:**
 
-- **Standard REINFORCE**: $\mathcal{L} = -\sum_{t=1}^T G_t \log \pi_\theta(a_t | s_t)$ (returns-to-go with discount factors)
-- **Our Approach**: $\mathcal{L} = -\sum_{t=1}^T \tilde{A}_t \log \pi_\theta(a_t | s_t) - \lambda \sum_{t=1}^T r_{\theta,t}$ (average-future-reward advantages + differentiable reward term)
+- **Standard REINFORCE**: $\\mathcal{L} = -\\sum_{t=1}^T G_t \\log \\pi_\\theta(a_t | s_t)$ (returns-to-go with discount factors)
+- **Our Approach**: $\\mathcal{L} = -\\sum_{t=1}^T \\tilde{A}_t \\log \\pi_\\theta(a_t | s_t) - \\lambda \\sum_{t=1}^T r_{\\theta,t}$ (average-future-reward advantages + differentiable reward term)
 
-where $G_t = \sum_{s=t}^T \gamma^{s-t} r_s$ vs. $\tilde{A}_t$ based on $\bar{R}_t(\tau) = \frac{1}{T-t+1} \sum_{s=t}^T r_{\theta,s}$
+where $G_t = \\sum_{s=t}^T \\gamma^{s-t} r_s$ vs. $\\tilde{A}_t$ based on $\\bar{R}_t(\\tau) = \\frac{1}{T-t+1} \\sum_{s=t}^T r_{\\theta,s}$
 
 **Advantages of Our Approach:**
 1. **Intuitive Credit Assignment**: Average future rewards more interpretable than discounted returns
@@ -321,16 +321,16 @@ total_loss = -(policy_term + reward_term)
 ```
 
 **Mathematical Correspondence:**
-- **Line `avg_rewards_after_t[:, t]`** ↔ $\bar{R}_t(\tau) = \frac{1}{T-t+1} \sum_{s=t}^T r_{\theta,s}$ - average future rewards
-- **Line `advantages`** ↔ $A_t = \bar{R}_t(\tau) - b_{\text{batch}}$ - GRPO advantages  
-- **Line `step_advantages * current_action_log_probs`** ↔ $\tilde{A}_t \cdot \log \pi_\theta(a_t | s_t)$ - advantage-weighted policy gradient
-- **Line `step_reward`** ↔ $r_{\theta,t}$ - instantaneous θ-dependent reward
-- **Line `reward_scaling * step_reward.sum()`** ↔ $\lambda \nabla_\theta r_{\theta,t}$ - scaled reward gradient
-- **Line `policy_term + reward_term`** ↔ complete chain rule decomposition $\nabla_\theta \mathcal{J}(\theta)$
+- **Line `avg_rewards_after_t[:, t]`** ↔ $\\bar{R}_t(\\tau) = \\frac{1}{T-t+1} \\sum_{s=t}^T r_{\\theta,s}$ - average future rewards
+- **Line `advantages`** ↔ $A_t = \\bar{R}_t(\\tau) - b_{\\text{batch}}$ - GRPO advantages  
+- **Line `step_advantages * current_action_log_probs`** ↔ $\\tilde{A}_t \\cdot \\log \\pi_\\theta(a_t | s_t)$ - advantage-weighted policy gradient
+- **Line `step_reward`** ↔ $r_{\\theta,t}$ - instantaneous θ-dependent reward
+- **Line `reward_scaling * step_reward.sum()`** ↔ $\\lambda \\nabla_\\theta r_{\\theta,t}$ - scaled reward gradient
+- **Line `policy_term + reward_term`** ↔ complete chain rule decomposition $\\nabla_\\theta \\mathcal{J}(\\theta)$
 
-**Key Insight:** Both the policy (action selection) and reward (outcome evaluation) are optimized using the same current model parameters $\theta$. This creates a self-consistent learning signal where the model learns to both select good actions AND accurately evaluate their outcomes.
+**Key Insight:** Both the policy (action selection) and reward (outcome evaluation) are optimized using the same current model parameters $\\theta$. This creates a self-consistent learning signal where the model learns to both select good actions AND accurately evaluate their outcomes.
 
-**Stability Analysis:** The reward gradient term $\nabla_\theta R_\theta(\tau)$ provides natural regularization by encouraging the model to assign higher probabilities to the value tokens it selected. This avoids the need for any KL penalty.
+**Stability Analysis:** The reward gradient term $\\nabla_\\theta R_\\theta(\\tau)$ provides natural regularization by encouraging the model to assign higher probabilities to the value tokens it selected. This avoids the need for any KL penalty.
 
 ---
 
@@ -366,7 +366,7 @@ Input: Hyperparameters γ, learning rate, batch size
 - **Context Window**: Up to model maximum (2048 for GPT-2, 4096+ for Llama)
 
 ### Training Configuration
-- **Optimizer**: AdamW with learning rate $5 \times 10^{-4}$
+- **Optimizer**: AdamW with learning rate $5 \\times 10^{-4}$
 - **Batch Size**: 4 trajectories per update
 - **Gradient Clipping**: Norm clipped to 1.0
 - **Episodes**: 10,000 total training episodes
@@ -391,7 +391,7 @@ Input: Hyperparameters γ, learning rate, batch size
 **Lemma 2 (Multi-Head Averaging):** The averaging operation over attention heads in Equation (6) preserves the probability distribution property:
 
 $$
-\sum_{k \in \mathcal{K}_t^{\text{available}}} \pi_\theta(k | s_t) = 1
+\\sum_{k \\in \\mathcal{K}_t^{\\text{available}}} \\pi_\\theta(k | s_t) = 1
 $$
 
 ### Chain Rule Properties
@@ -399,26 +399,26 @@ $$
 **Theorem 3 (Self-Consistent Learning):** The chain rule approach ensures self-consistent parameter updates:
 
 $$
-\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}[R_\theta(\tau) \cdot \nabla_\theta \log \pi_\theta(\tau) + \nabla_\theta R_\theta(\tau)]
+\\nabla_\\theta \\mathcal{J}(\\theta) = \\mathbb{E}_{\\tau \\sim \\pi_\\theta}[R_\\theta(\\tau) \\cdot \\nabla_\\theta \\log \\pi_\\theta(\\tau) + \\nabla_\\theta R_\\theta(\\tau)]
 $$
 
-Both terms optimize the same parameters $\theta$, creating a unified learning signal where the model learns to both select high-reward actions AND accurately evaluate their outcomes.
+Both terms optimize the same parameters $\\theta$, creating a unified learning signal where the model learns to both select high-reward actions AND accurately evaluate their outcomes.
 
 ### Average vs Discounted Weighting: Trade-offs
 
 We support two ways to construct stepwise weighting targets for advantages:
 
 1. Average future rewards (default):
-   - $\bar{R}_t = \frac{1}{T-t+1} \sum_{s=t}^T r_{\theta,s}$
+   - $\\bar{R}_t = \\frac{1}{T-t+1} \\sum_{s=t}^T r_{\\theta,s}$
    - Pros: interpretable credit assignment; robust to "gaming" easy short segments because each action is credited for its impact on the remainder of the trajectory
    - Cons: longer effective gradient paths (each action influences many future rewards), potentially higher variance
 
 2. Discounted returns:
-   - $G_t = \sum_{s=t}^T \gamma^{s-t} r_{\theta,s}$ with $\gamma \in (0,1]$
-   - Pros: shorter effective credit horizon; can stabilize training when later rewards are noisier; tunable temporal bias via $\gamma$
-   - Cons: introduces extra hyperparameter; may over-emphasize immediate/"easy" gains if $\gamma$ is small
+   - $G_t = \\sum_{s=t}^T \\gamma^{s-t} r_{\\theta,s}$ with $\\gamma \\in (0,1]$
+   - Pros: shorter effective credit horizon; can stabilize training when later rewards are noisier; tunable temporal bias via $\\gamma$
+   - Cons: introduces extra hyperparameter; may over-emphasize immediate/"easy" gains if $\\gamma$ is small
 
-Gradient path considerations: With average weighting, each action receives signal from all subsequent rewards, which lengthens the dependency chain but is still handled by modern autograd through the explicit recomputation of $r_{\theta,t}$. Discounting reduces the weight of distant rewards, shortening the effective horizon and often reducing variance.
+Gradient path considerations: With average weighting, each action receives signal from all subsequent rewards, which lengthens the dependency chain but is still handled by modern autograd through the explicit recomputation of $r_{\\theta,t}$. Discounting reduces the weight of distant rewards, shortening the effective horizon and often reducing variance.
 
 Given your preference for average weighting (to avoid gaming by selecting trivially easy subsegments), the average formulation is principled here because each episode considers a permutation of a full datapoint, and the average encourages consistent, globally beneficial selections.
 
@@ -439,21 +439,21 @@ This mathematical formulation describes a sophisticated reinforcement learning s
 The key innovation is the **average future reward θ-dependent formulation** with proper chain rule application:
 
 $$
-\nabla_\theta \mathcal{J}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \sum_{t=1}^T \tilde{A}_t \cdot \nabla_\theta \log \pi_\theta(a_t | s_t) + \lambda \sum_{t=1}^T \nabla_\theta r_{\theta,t} \right]
+\\nabla_\\theta \\mathcal{J}(\\theta) = \\mathbb{E}_{\\tau \\sim \\pi_\\theta} \\left[ \\sum_{t=1}^T \\tilde{A}_t \\cdot \\nabla_\\theta \\log \\pi_\\theta(a_t | s_t) + \\lambda \\sum_{t=1}^T \\nabla_\\theta r_{\\theta,t} \\right]
 $$
 
-where $\tilde{A}_t$ are normalized advantages based on average future rewards $\bar{R}_t(\tau) = \frac{1}{T-t+1} \sum_{s=t}^T r_{\theta,s}$.
+where $\\tilde{A}_t$ are normalized advantages based on average future rewards $\\bar{R}_t(\\tau) = \\frac{1}{T-t+1} \\sum_{s=t}^T r_{\\theta,s}$.
 
 This creates two complementary learning signals:
 - **Policy gradient term**: Uses normalized advantages based on average future rewards for intuitive credit assignment
-- **Reward gradient term**: Directly optimizes the model's ability to generate high rewards (scaled by λ=0.1)
+- **Reward gradient term**: Directly optimizes the model's ability to generate high rewards (scaled by $\\lambda$=0.1)
 
 **Advantages of the Current Approach:**
 - **Intuitive Credit Assignment**: Average future rewards more interpretable than discounted returns
-- **No Discount Factors**: Eliminates γ hyperparameter tuning and complex temporal discounting
+- **No Discount Factors**: Eliminates $\\gamma$ hyperparameter tuning and complex temporal discounting
 - **Stable Training**: GRPO baseline and advantage normalization reduce variance
 - **Balanced Components**: Loss terms scaled to similar magnitudes (~1-10 range)
-- **Self-Consistent**: No mismatch between policy and reward model (both use current θ)
+- **Self-Consistent**: No mismatch between policy and reward model (both use current $\\theta$)
 - **Natural Regularization**: Reward gradient term provides stability without artificial KL penalties
 - **Mathematically Rigorous**: Proper chain rule application for θ-dependent objectives
 - **Unified Learning**: Action selection and outcome evaluation optimized jointly

--- a/docs/improved_policy_loss.md
+++ b/docs/improved_policy_loss.md
@@ -15,7 +15,7 @@ This document describes the improvements made to the policy loss computation in 
 
 Instead of using average rewards across the trajectory, we now compute discounted returns (rewards-to-go):
 
-```python
+```
 returns[t] = r_t + γ * r_{t+1} + γ² * r_{t+2} + ...
 ```
 
@@ -34,7 +34,7 @@ We implement **GRPO (Group Relative Policy Optimization)** style baseline:
 - This naturally handles the fact that earlier steps have higher returns due to more future rewards
 - Advantages sum to zero at each timestep by construction
 
-```python
+```
 baseline[t] = mean(returns[:, t])  # Average return at timestep t across batch
 advantages[:, t] = returns[:, t] - baseline[t]
 ```
@@ -49,28 +49,28 @@ Benefits of GRPO baseline:
 
 To encourage exploration:
 - **Token queries**: Use categorical entropy from the softmax distribution
-- **Vector queries**: Use Gaussian entropy: `H = 0.5 * d * (1 + log(2π)) + d * log(σ)`
+- **Vector queries**: Use Gaussian entropy: $H = 0.5 \\times d \\times (1 + \\log(2\\pi)) + d \\times \\log(\\sigma)$
 
 ### 4. Loss Formulation
 
 The total loss is now:
 
-```
-L = L_policy + β * L_KL - α * H_entropy
-```
+$$
+L = L_{\\text{policy}} + \\beta \\times L_{\\text{KL}} - \\alpha \\times H_{\\text{entropy}}
+$$
 
 Where:
-- `L_policy = -E[log π(a|s) * A(s,a)]` (policy gradient with advantages)
-- `L_KL` = KL divergence between current and previous policy
-- `H_entropy` = Entropy of the policy distribution
-- `β` = KL penalty coefficient (default: 0.1)
-- `α` = Entropy coefficient (default: 0.01)
+- $L_{\\text{policy}} = -\\mathbb{E}[\\log \\pi(a|s) \\times A(s,a)]$ (policy gradient with advantages)
+- $L_{\\text{KL}}$ = KL divergence between current and previous policy
+- $H_{\\text{entropy}}$ = Entropy of the policy distribution
+- $\\beta$ = KL penalty coefficient (default: 0.1)
+- $\\alpha$ = Entropy coefficient (default: 0.01)
 
 ## Configuration Parameters
 
 New parameters in `src/config.py`:
 
-```python
+```
 GAMMA = 0.99          # Discount factor for returns
 GAE_LAMBDA = 0.95     # GAE lambda (for future use)
 ENTROPY_COEF = 0.01   # Entropy bonus coefficient
@@ -89,7 +89,7 @@ USE_GRPO_BASELINE = True  # Use GRPO-style baseline
 
 ### For Vector-based Queries
 
-1. Generate query vectors from N(μ(s), σ²I)
+1. Generate query vectors from $\\mathcal{N}(\\mu(s), \\sigma^2 I)$
 2. Store log prob of sampled vector under the Gaussian
 3. Apply policy gradient loss with advantages
 4. Add Gaussian entropy bonus
@@ -105,6 +105,6 @@ USE_GRPO_BASELINE = True  # Use GRPO-style baseline
 ## Future Improvements
 
 1. **Value function baseline**: Train a value head to predict returns
-2. **GAE implementation**: Use TD(λ) for advantage estimation
+2. **GAE implementation**: Use TD($\\lambda$) for advantage estimation
 3. **PPO clipping**: Add probability ratio clipping for stability
 4. **Better KL computation**: Store or regenerate previous policy means 


### PR DESCRIPTION
Fix math formatting in `MATHEMATICAL_FORMULATION.md` and `improved_policy_loss.md` by escaping LaTeX backslashes and converting math code blocks to proper LaTeX.

---
<a href="https://cursor.com/background-agent?bcId=bc-0959da72-6de2-4dc6-a35d-8728ca07f122">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0959da72-6de2-4dc6-a35d-8728ca07f122">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

